### PR TITLE
Fix nokogiri via bundle update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,14 +158,14 @@ GEM
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
     mercenary (0.3.6)
-    mini_portile2 (2.2.0)
+    mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
     minitest (5.10.1)
     multipart-post (2.0.0)
     net-dns (0.8.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     pathutil (0.14.0)
@@ -201,4 +201,4 @@ DEPENDENCIES
   test-unit
 
 BUNDLED WITH
-   1.14.6
+   1.15.4


### PR DESCRIPTION
This fixes the warning that keeps showing up in places where this repository is referenced. 

@githubtraining/trainers tested locally and it works, but would love another 👍 

Courtesy of @hectorsector 
> `bundle install` followed by `bundle exec jekyll serve` should work while testing this repo